### PR TITLE
Updated workflow status badge with link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 ## KONG-AWS-REQUEST-SIGNING
 
-![build status](https://github.com/LEGO/kong-aws-request-signing/workflows/Build/badge.svg)
+[![Build](https://github.com/LEGO/kong-aws-request-signing/actions/workflows/build.yml/badge.svg)](https://github.com/LEGO/kong-aws-request-signing/actions/workflows/build.yml)
 
 ### About
 


### PR DESCRIPTION
Added link to workflow status page by using the built-in **Create status badge** feature found here [Actions](https://github.com/LEGO/kong-aws-request-signing/actions/workflows/build.yml).
<img width="258" alt="Screenshot 2022-09-06 at 21 23 15" src="https://user-images.githubusercontent.com/736606/188721298-84de1b88-94f4-4ac9-a8e2-ac5342d69391.png">
