### PR TITLE
Fixed access event handler.

### DIFF
--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -105,7 +105,7 @@ local function get_iam_credentials(sts_conf,refresh)
   return iam_role_credentials
 end
 
-function AWSLambdaSTS.access(conf)
+function AWSLambdaSTS.access(self, conf)
   local service = kong.router.get_service()
 
   if service == nil then

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -108,6 +108,8 @@ end
 function AWSLambdaSTS.access(self, conf)
   local service = kong.router.get_service()
 
+  kong.log.debug(self);
+
   if service == nil then
     return kong.response.exit(500, { message = "Unable to retrive bound service!" })
   end


### PR DESCRIPTION
The access function passes self as the first parameter and the config as the second, which can be passed as `.(self, config )` or `:(config)`. As we use the first option, we need to pass `self` as the first parameter, which we don't do now, and the plugin is failing to execute.

- Update: updated access event handle function.

### Testing

- [x] Has been tested locally.
