### PR TITLE
Kong engineering team review

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,3 +9,7 @@ globals = {
     "ngx",
     "_TEST"
 }
+
+ignore = {
+    "212/self",  -- don't complain about functions not using their implicit self arguments
+}

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -73,14 +73,8 @@ local function get_iam_credentials(sts_conf,refresh)
     return kong.response.exit(401, { message = "Unable to get the IAM credentials! Check token!" })
   end
 
-  local expires = 0
-
-  if iam_role_credentials then
-    expires = iam_role_credentials.expiration
-  end
-  local now = get_now()
-
-  if ((now + 60) >= expires) then
+  if not iam_role_credentials
+    or (get_now() + 60) > iam_role_credentials.expiration then
     kong.cache:invalidate_local(iam_role_cred_cache_key)
     iam_role_credentials, err = kong.cache:get(
       iam_role_cred_cache_key,

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -111,7 +111,7 @@ function AWSLambdaSTS:access(conf)
 
   local iam_role_credentials = get_iam_credentials(sts_conf, request_headers["x-sts-refresh"])
 
-  upstream_headers = {
+  local upstream_headers = {
     ["x-authorization"] = kong.request.get_headers().authorization,
     ["x-amz-security-token"] = iam_role_credentials.session_token,
     host = service.host,

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -101,7 +101,7 @@ if _TEST then
   AWSLambdaSTS._get_iam_credentials = get_iam_credentials
 end
 
-function AWSLambdaSTS.access(_self, conf)
+function AWSLambdaSTS:access(conf)
   local service = kong.router.get_service()
 
   if service == nil then

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -69,11 +69,11 @@ local function get_iam_credentials(sts_conf,refresh)
   )
 
   if err then
-    kong.log.err(err);
+    kong.log.err(err)
     return kong.response.exit(401, { message = "Unable to get the IAM credentials! Check token!" })
   end
 
-  local expires = 0;
+  local expires = 0
 
   if iam_role_credentials then
     expires = iam_role_credentials.expiration
@@ -89,7 +89,7 @@ local function get_iam_credentials(sts_conf,refresh)
       sts_conf
     )
     if err then
-      kong.log.err(err);
+      kong.log.err(err)
       return kong.response.exit(401, { message = "Unable to refresh expired IAM credentials! Check token!" })
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -12,7 +12,6 @@ local set_raw_body = kong.service.request.set_raw_body
 
 local IAM_CREDENTIALS_CACHE_KEY_PATTERN = "plugin.aws-request-signing.iam_role_temp_creds.%s"
 local AWS_PORT = 443
-local re_gmatch = ngx.re.gmatch
 
 local AWSLambdaSTS = {}
 
@@ -40,18 +39,12 @@ local function retrieve_token()
     if type(token_header) == "table" then
       token_header = token_header[1]
     end
-    local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)")
-    if not iterator then
-      kong.log.err(iter_err)
-    end
 
-    local m, err = iterator()
+    local captures, err = ngx.re.match(token_header, [[ \s* Bearer \s+ (.+) ]], "joxi", nil)
     if err then
       kong.log.err(err)
-    end
-
-    if m and #m > 0 then
-      return m[1]
+    elseif captures then
+      return captures[1]
     end
   end
 end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -105,7 +105,8 @@ function AWSLambdaSTS:access(conf)
   local service = kong.router.get_service()
 
   if service == nil then
-    return kong.response.exit(500, { message = "Unable to retrieve bound service!" })
+    kong.log.err("Unable to retrieve bound service!")
+    return kong.response.exit(500, { message = "Internal server error" })
   end
   local host = service.host
 

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -117,9 +117,10 @@ function AWSLambdaSTS.access(_self, conf)
   }
 
   local upstream_headers = {}
-
-  local iam_role_credentials = get_iam_credentials(sts_conf,upstream_headers["x-sts-refresh"])
-
+  -- FIXME: It seems that upstream_headers["x-sts-refresh"] always is nil at this point.
+  local iam_role_credentials = get_iam_credentials(sts_conf, upstream_headers["x-sts-refresh"])
+  -- FIXME: Suggest making the initialization of upstream_headers into an array initializer
+  -- instead of repeated assignments for consistency.
   upstream_headers["x-authorization"] = kong.request.get_headers().authorization
   upstream_headers["x-amz-security-token"] = iam_role_credentials.session_token
   upstream_headers.authorization = nil

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -1,4 +1,4 @@
-local aws_v4 = require "kong.plugins.aws-request-signing.sigv4"
+local sigv4 = require "kong.plugins.aws-request-signing.sigv4"
 local meta = require "kong.meta"
 
 local kong = kong
@@ -141,7 +141,7 @@ function AWSLambdaSTS.access(_self, conf)
     secret_key = iam_role_credentials.secret_key,
   }
 
-  local request, err = aws_v4(opts)
+  local request, err = sigv4(opts)
   if err then
     return error(err)
   end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -3,12 +3,8 @@ local meta = require "kong.meta"
 
 local kong = kong
 local ngx = ngx
-local ngx_update_time = ngx.update_time
-local ngx_now = ngx.now
-local ngx_var = ngx.var
 local error = error
 local type = type
-local fmt = string.format
 
 local set_headers = kong.service.request.set_headers
 local get_raw_body = kong.request.get_raw_body
@@ -33,8 +29,8 @@ local function fetch_aws_credentials(sts_conf)
 end
 
 local function get_now()
-  ngx_update_time()
-  return ngx_now() -- time is kept in seconds
+  ngx.update_time()
+  return ngx.now() -- time is kept in seconds
 end
 
 local function retrieve_token()
@@ -65,7 +61,7 @@ if _TEST then
 end
 
 local function get_iam_credentials(sts_conf,refresh)
-  local iam_role_cred_cache_key = fmt(IAM_CREDENTIALS_CACHE_KEY_PATTERN, sts_conf.RoleArn)
+  local iam_role_cred_cache_key = string.format(IAM_CREDENTIALS_CACHE_KEY_PATTERN, sts_conf.RoleArn)
 
   if refresh then
     kong.log.debug("invalidated iam_role cache!")
@@ -143,7 +139,7 @@ function AWSLambdaSTS.access(_self, conf)
     method = kong.request.get_method(),
     headers = upstream_headers,
     body = get_raw_body(),
-    path = ngx_var.upstream_uri,
+    path = ngx.var.upstream_uri,
     host = host,
     port = AWS_PORT,
     query = kong.request.get_raw_query(),

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -105,7 +105,7 @@ function AWSLambdaSTS.access(_self, conf)
   local service = kong.router.get_service()
 
   if service == nil then
-    return kong.response.exit(500, { message = "Unable to retrive bound service!" })
+    return kong.response.exit(500, { message = "Unable to retrieve bound service!" })
   end
   local host = service.host
 

--- a/kong/plugins/aws-request-signing/sigv4.lua
+++ b/kong/plugins/aws-request-signing/sigv4.lua
@@ -136,8 +136,8 @@ local function prepare_awsv4_request(tbl)
   end
 
   local lowerHeaders = {
-    ["x-amz-date"] = req_date;
-    host = host_header;
+    ["x-amz-date"] = req_date,
+    host = host_header
   }
 
   for k, v in pairs(req_headers) do

--- a/kong/plugins/aws-request-signing/sigv4.lua
+++ b/kong/plugins/aws-request-signing/sigv4.lua
@@ -19,9 +19,7 @@ end
 
 local CHAR_TO_HEX = {};
 for i = 0, 255 do
-  local char = string.char(i)
-  local hex = string.format("%02x", i)
-  CHAR_TO_HEX[char] = hex
+  CHAR_TO_HEX[string.char(i)] = string.format("%02x", i)
 end
 
 local function hmac(secret, data)
@@ -35,7 +33,7 @@ local function hash(str)
 end
 
 local function hex_encode(str) -- From prosody's util.hex
-  return (str:gsub(".", CHAR_TO_HEX))
+  return str:gsub(".", CHAR_TO_HEX)
 end
 
 local function percent_encode(char)
@@ -65,8 +63,7 @@ local function canonicalise_path(path)
     segments[len] = nil
   end
   segments[0] = ""
-  local segmentsString = table.concat(segments, "/", 0, len)
-  return segmentsString
+  return table.concat(segments, "/", 0, len)
 end
 
 local function canonicalise_query_string(query)
@@ -84,8 +81,7 @@ local function derive_signing_key(kSecret, date, region, service)
   local kDate = hmac("AWS4" .. kSecret, date)
   local kRegion = hmac(kDate, region)
   local kService = hmac(kRegion, service)
-  local kSigning = hmac(kService, "aws4_request")
-  return kSigning
+  return hmac(kService, "aws4_request")
 end
 
 local function prepare_awsv4_request(tbl)
@@ -220,7 +216,7 @@ local function prepare_awsv4_request(tbl)
   local scheme = tls and "https" or "http"
   local url = scheme .. "://" .. host_header .. target
 
-  local returned = {
+  return {
     url = url,
     host = host,
     port = port,
@@ -230,8 +226,6 @@ local function prepare_awsv4_request(tbl)
     headers = lowerHeaders,
     body = req_payload,
   }
-
-  return returned
 end
 
 return prepare_awsv4_request

--- a/spec/handler_spec.lua
+++ b/spec/handler_spec.lua
@@ -65,24 +65,22 @@ _G._TEST = true -- tell scripts we're testing so it can export the public functi
 
 local handler = require("kong.plugins.aws-request-signing.handler")
 
+-- FIXME: describe/it arguments are meant to be consumed by humans, no need to make them resemble identifiers.
 describe("retrieve_token_should", function()
   it("return_auth_token_from_correct_header", function()
-    local returnedToken = handler._retrieve_token()
+    local returnedToken = handler._retrieve_token("bearer " .. authGuid)
     assert.equal(authGuid, returnedToken)
   end)
   it("return_auth_token_from_correct_header_with_capital_B", function()
-    mock_request_headers["authorization"] = "Bearer " .. authGuid
-    local returnedToken = handler._retrieve_token()
+    local returnedToken = handler._retrieve_token("Bearer " .. authGuid)
     assert.equal(authGuid, returnedToken)
   end)
   it("return_nil_if_header_doesnt_contain_bearer", function()
-    mock_request_headers["authorization"] = "Basic whatever"
-    local returnedToken = handler._retrieve_token()
+    local returnedToken = handler._retrieve_token("Basic whatever")
     assert.falsy(returnedToken)
   end)
   it("return_nil_if_header_doesnt_exist", function()
-    mock_request_headers["authorization"] = nil
-    local returnedToken = handler._retrieve_token()
+    local returnedToken = handler._retrieve_token(nil)
     assert.falsy(returnedToken)
   end)
 end)


### PR DESCRIPTION
The Kong gateway engineering team has been asked to review this plugin. Overall, we found the code to be straightforward and easy to understand. A couple of minor issues have been located and we've organized this PR into a number of separate commits with recommendations for your consideration.

Some internal discussions surrounded the practice of declaring local variables to shadow global variables of the same name for performance gains. While this practice is common and can actually make a noticable impact when using the Lua interpreter, it is much less useful with LuaJIT and its dynamic run-time optimization behavior. The speed difference between local and global variable access is neglible even with the Lua interpreter unless the variable is accessed in an inner loop that is executed frequently. The code paths in this plugin don't seem to be executed often enough to warrant localizing global variables.

We found one actual bug: It seems that the "X-STS-Refresh" header should trigger an unconditional refresh. This header was incorrectly tested, however. A proposed fix is in a separate commit in this PR.