### PR TITLE
Feat/upstream rewrite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'kong/**'
+      - 'spec/**'
 jobs:
   linting:
     name: Linting code.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - 'kong/**/*.lua'
-      - 'spec/*.lua'
+      - 'kong'
+      - 'spec'
 
 jobs:
   linting:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'kong'
-      - 'spec'
-
 jobs:
   linting:
     name: Linting code.

--- a/Readme.dev.md
+++ b/Readme.dev.md
@@ -78,11 +78,11 @@ Run the command on pongo host machine.
   curl -i -X POST \
    --url $kong_admin_url/services/$service_name/plugins/ \
    --data "name=$plugin_name" \
-   --data 'config.aws_assume_role_arn=arn:aws:iam::109381819741:role/lambda-access-role' \
+   --data 'config.aws_assume_role_arn=arn:aws:iam::100000000000:role/lambda-access-role' \
    --data 'config.aws_assume_role_name=lambda-access-role'\
    --data 'config.aws_region=eu-west-1' \
    --data 'config.aws_service=lambda' \
-   --data 'config.override_target_host=2wmbzq5efmua7pehie6wpktozm0nkeog.lambda-url.eu-west-1.on.aws' \
+   --data 'config.override_target_host=someString.lambda-url.eu-west-1.on.aws' \
    --data 'config.override_target_port=443' \
    --data 'config.override_target_protocol=https'
   ```

--- a/Readme.dev.md
+++ b/Readme.dev.md
@@ -2,7 +2,7 @@
 
 ## Testing
 
-`Unit tests are not done yet`
+`Unit tests are not fully done yet`
 
 Performance test was done using K6 and 1400 up to 5800 virtual users.
 

--- a/Readme.dev.md
+++ b/Readme.dev.md
@@ -1,7 +1,8 @@
 # This document is intended for Developers
 
-### Testing
-  *Unit tests are not done yet*
+## Testing
+
+`Unit tests are not done yet`
 
 Performance test was done using K6 and 1400 up to 5800 virtual users.
 
@@ -16,60 +17,83 @@ Have a look at the table below:
 
 Based on the results above, we assume that this plugin and Kong is more reliable than AWS API Gateway, at least in the case when a lot of users have to be served.
 
-### Plugin Development
+## Plugin Development
+
 Below you will find some actions you might want to perform during plugin development
 
-* #### restarting dev env
+* ### restarting dev env
+
   ```sh
   pongo down && pongo run --no-cassandra && pongo shell
   ```
 
-* #### starting kong
+* ### starting kong
+
   ```sh
   kong migrations bootstrap --force && kong start
   ```
 
-* #### reloading kong
+* ### inspect logs
+
+  ```sh
+  pongo tail
+  ```
+
+Run the command on pongo host machine.
+
+* ### reloading kong
+
   ```sh
   kong reload
   ```
 
-* #### exporting ENV var used below
+* ### exporting ENV var used below
+
   ```sh
-  export kong_proxf_url=http://localhost:8000
+  export kong_proxy_url=http://localhost:8000
   export kong_admin_url=http://localhost:8001
   export service_name=echo 
   export plugin_name=aws-request-signing
-  export lambda_url=http://example.com
+  export lambda_host=example.com
   ```
 
-* #### exporting Token used to AssumeRoleWithWebIdentity
+* ### exporting Token used to AssumeRoleWithWebIdentity
+
   ```sh
   export auth_token=
   ```
 
-* #### Simple service + route + plugin configuration
+* ### Simple service + route + plugin configuration
+
   ```sh
   curl -i -X POST \
    --url $kong_admin_url/services/ \
    --data "name=$service_name" \
-   --data "url=https://$lambda_url/" && curl -i -X POST \
+   --data "url=http://$lambda_host/"
+   
+  curl -i -X POST \
    --url $kong_admin_url/services/$service_name/routes \
-   --data "paths[]=/$service_name" && curl -i -X POST \
+   --data "paths[]=/$service_name"
+   
+  curl -i -X POST \
    --url $kong_admin_url/services/$service_name/plugins/ \
    --data "name=$plugin_name" \
-   --data 'config.aws_assume_role_arn=arn:aws:iam::3000453029296:role/azure-lambda' \
-   --data 'config.aws_assume_role_name=azure-lambda'\
+   --data 'config.aws_assume_role_arn=arn:aws:iam::109381819741:role/lambda-access-role' \
+   --data 'config.aws_assume_role_name=lambda-access-role'\
    --data 'config.aws_region=eu-west-1' \
-   --data 'config.aws_service=lambda' 
+   --data 'config.aws_service=lambda' \
+   --data 'config.override_target_host=2wmbzq5efmua7pehie6wpktozm0nkeog.lambda-url.eu-west-1.on.aws' \
+   --data 'config.override_target_port=443' \
+   --data 'config.override_target_protocol=https'
   ```
 
-* #### Configuring a service a route and adding the Kong Request-Transformer and this plugin
+* ### Configuring a service a route and adding the Kong Request-Transformer and this plugin
+
   ```sh
   curl -i -X POST \
    --url $kong_admin_url/services/ \
    --data "name=$service_name" \
-   --data "url=https://$lambda_url/" && curl -i -X POST \
+   --data "url=https://$lambda_host/" && curl -i -X POST \
    --url $kong_admin_url/services/$service_name/routes \
    --data "paths[]=/digital/api/(?<g1>$service_name)" && curl -i -X POST \
    --url $kong_admin_url/services/$service_name/plugins/ \
@@ -83,36 +107,40 @@ Below you will find some actions you might want to perform during plugin develop
    --data 'config.aws_service=lambda' 
   ```
 
+* ### Simple Kong call
 
-* #### Simple Kong call (Request-Transformer activated)
-  ```sh
-  curl -v -H "Authorization: Bearer $auth_token" $kong_proxy_url/digital/api/$service_name 
-  ```
-
-* #### Simple Kong call
   ```sh
   curl -v -H "Authorization: Bearer $auth_token" $kong_proxy_url/$service_name
   ```
 
-* #### Complex Kong call 
+* ### Simple Kong call (Request-Transformer activated)
+
+  ```sh
+  curl -v -H "Authorization: Bearer $auth_token" $kong_proxy_url/digital/api/$service_name 
+  ```
+
+* ### Complex Kong call
+
   ```sh
   curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" $kong_proxy_url/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
   ```
 
-* #### Complex Kong call (Request-Transformer activated)
+* ### Complex Kong call (Request-Transformer activated)
+
   ```sh
   curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" $kong_proxy_url/digital/api/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
   ```
 
-* #### Just like above with forced credentials refresh.
+* ### Just like above with forced credentials refresh.
+
   ```sh
   curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" -H "x-sts-refresh: true" $kong_proxy_url/digital/api/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
   ```
 
-* #### Change upstream of the service
+* ### Change upstream of the service
+
   ```sh
   curl -i -X PATCH \
    --url "$kong_admin_url/services/$service_name" \
    --data "url=https://new.example.com/"
   ```
-

--- a/Readme.dev.md
+++ b/Readme.dev.md
@@ -35,11 +35,11 @@ Below you will find some actions you might want to perform during plugin develop
 
 * ### inspect logs
 
+  Run the command on pongo host machine.
+
   ```sh
   pongo tail
   ```
-
-Run the command on pongo host machine.
 
 * ### reloading kong
 
@@ -63,7 +63,7 @@ Run the command on pongo host machine.
   export auth_token=
   ```
 
-* ### Simple service + route + plugin configuration
+* ### Configuring a simple service + route + plugin
 
   ```sh
   curl -i -X POST \
@@ -87,36 +87,10 @@ Run the command on pongo host machine.
    --data 'config.override_target_protocol=https'
   ```
 
-* ### Configuring a service a route and adding the Kong Request-Transformer and this plugin
-
-  ```sh
-  curl -i -X POST \
-   --url $kong_admin_url/services/ \
-   --data "name=$service_name" \
-   --data "url=https://$lambda_host/" && curl -i -X POST \
-   --url $kong_admin_url/services/$service_name/routes \
-   --data "paths[]=/digital/api/(?<g1>$service_name)" && curl -i -X POST \
-   --url $kong_admin_url/services/$service_name/plugins/ \
-   --data "name=request-transformer" \
-   --data 'config.replace.uri=/$(uri_captures.g1)'  && curl -i -X POST \
-   --url $kong_admin_url/services/$service_name/plugins/ \
-   --data "name=$plugin_name" \
-   --data 'config.aws_assume_role_arn=arn:aws:iam::300063049296:role/azure-lambda' \
-   --data 'config.aws_assume_role_name=azure-lambda'\
-   --data 'config.aws_region=eu-west-1' \
-   --data 'config.aws_service=lambda' 
-  ```
-
 * ### Simple Kong call
 
   ```sh
   curl -v -H "Authorization: Bearer $auth_token" $kong_proxy_url/$service_name
-  ```
-
-* ### Simple Kong call (Request-Transformer activated)
-
-  ```sh
-  curl -v -H "Authorization: Bearer $auth_token" $kong_proxy_url/digital/api/$service_name 
   ```
 
 * ### Complex Kong call
@@ -125,16 +99,10 @@ Run the command on pongo host machine.
   curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" $kong_proxy_url/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
   ```
 
-* ### Complex Kong call (Request-Transformer activated)
+* ### Just like above with forced credentials refresh
 
   ```sh
-  curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" $kong_proxy_url/digital/api/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
-  ```
-
-* ### Just like above with forced credentials refresh.
-
-  ```sh
-  curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" -H "x-sts-refresh: true" $kong_proxy_url/digital/api/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
+  curl -v -H "Authorization: Bearer $auth_token" -H "Content-Type: application/json" -H "x-sts-refresh: true" $kong_proxy_url/$service_name?query=true --data '{"username":"xyz","password":"xyz"}' 
   ```
 
 * ### Change upstream of the service

--- a/Readme.md
+++ b/Readme.md
@@ -37,11 +37,11 @@ override_target_host - To be used when deploying multiple lambdas on a single Ko
 type = "string"
 required = false
 
-override_target_port - To be used when deploying a lambda on a Kong service that listens on a port other than `443`
+override_target_port - To be used when deploying a Lambda on a Kong service that listens on a port other than `443`
 type = "number"
 required = false
 
-override_target_protocol - To be used when deployinglambda on a Kong service that has a protocol different than `https`
+override_target_protocol - To be used when deploying a Lambda on a Kong service that has a protocol different than `https`
 type = "string",
 one_of = "http", "https"
 required = false
@@ -51,10 +51,10 @@ required = false
 
 The plugin can be enabled on a per service as well as on a per route basis.
 
-When enabling the plugin on a service/route, the plugin will use the service upstream as the lambda target, unless `override_target_host` is specified.
-This configuration works fine only if a single Lambda is used in the entire service, if multiple lambdas are specified on a per path basis, without the `override_target_host` configured, they will all use the service upstream as the target, which will obviously fail.
+When enabling the plugin on a service/route, the plugin will use the service upstream as the Lambda target, unless `override_target_host` is specified.
+This configuration works fine only if a single Lambda is used in the entire service, if multiple lambdas are specified on a per path basis, without the `override_target_host` configured, they will all use the service upstream as the target and if the upstream is a Lambda, that means that all the routes will be served by the same service-level Lambda.
 
-***TLDR: If multiple lambdas are required for a single Kong service (which most likely is the case), the correct configuration is having a Kong route for each Lambda, enabling the plugin o a per-route basis with `override_target_host` on each of them, so the requests are routed to the right lambda.***
+***TLDR: If multiple lambdas are required for a single Kong service, the correct configuration is having a Kong route for each Lambda, enabling the plugin o a per-route basis with `override_target_host` on each of them, so the requests are routed to the right Lambda.***
 
 ## AWS Setup required
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-## KONG-AWS-REQUEST-SIGNING
+# KONG-AWS-REQUEST-SIGNING
 
 [![Build](https://github.com/LEGO/kong-aws-request-signing/actions/workflows/build.yml/badge.svg)](https://github.com/LEGO/kong-aws-request-signing/actions/workflows/build.yml)
 
-### About
+## About
 
 This plugin will sign a request with AWS SIGV4 and temporary credentials from `sts.amazonaws.com` requested using an OAuth token.
 
@@ -12,7 +12,7 @@ At the same time it drives down cost and complexity by excluding the AWS API Gat
 
 The required AWS setup to make the plugin work with your Lambda HTTPS endpoint is described below.
 
-### Plugin configuration parameters:
+## Plugin configuration parameters
 
 ```lua
 aws_assume_role_arn - ARN of the IAM role that the plugin will try to assume
@@ -29,13 +29,35 @@ aws_region - AWS region where your Lambda is deployed to
 type = "string"
 required = true
 
-
 aws_service - AWS Service you are trying to access (lambda)
 type = "string"
 required = true
+
+override_target_host - To be used when deploying multiple lambdas on a single Kong service (because lambdas have differennt URLs)
+type = "string"
+required = false
+
+override_target_port - To be used when deploying a lambda on a Kong service that listens on a port other than `443`
+type = "number"
+required = false
+
+override_target_protocol - To be used when deployinglambda on a Kong service that has a protocol different than `https`
+type = "string",
+one_of = "http", "https"
+required = false
 ```
 
-### AWS Setup required
+## Service vs Route scoped configuration
+
+The plugin can be enabled on a per service as well as on a per route basis.
+
+When enabling the plugin on a service/route, the plugin will use the service upstream as the lambda target, unless `override_target_host` is specified.
+This configuration works fine only if a single Lambda is used in the entire service, if multiple lambdas are specified on a per path basis, without the `override_target_host` configured, they will all use the service upstream as the target, which will obviously fail.
+
+***TLDR: If multiple lambdas are required for a single Kong service (which most likely is the case), the correct configuration is having a Kong route for each Lambda, enabling the plugin o a per-route basis with `override_target_host` on each of them, so the requests are routed to the right lambda.***
+
+## AWS Setup required
+
 1. You have a [Lambda function](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#) deployed with `Function URL` enabled and Auth type : `AWS_IAM`
 
 <details>
@@ -47,11 +69,10 @@ required = true
 
 2. Your OpenID Connect provider is added to [AWS IAM](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/identity_providers)
 3. You have a role with  `arn:aws:iam::aws:policy/AWSLambda_FullAccess` permision and the trust relationship below:
-   
+
 <details>
 <summary>Show JSON</summary>
 <br>
-
 
 ```json
 {
@@ -72,6 +93,7 @@ required = true
     ]
 }
 ```
+
 </details>
 
 So if your provider is `https://sts.windows.net/organization.onmicrosoft.com/` and your app identity is `app_identity_1`, the trust relationship above will look like:
@@ -99,23 +121,26 @@ So if your provider is `https://sts.windows.net/organization.onmicrosoft.com/` a
     ]
 }
 ```
+
 </details>
 
-### About the code and differences from [Kong Lambda Plugin](https://github.com/Kong/kong/blob/master/kong/plugins/aws-lambda)
+## About the code and differences from [Kong Lambda Plugin](https://github.com/Kong/kong/blob/master/kong/plugins/aws-lambda)
+
 Some of the code was reused from [Kong Lambda Plugin](https://github.com/Kong/kong/blob/master/kong/plugins/aws-lambda) specifically the [SIGV4 creation](https://github.com/Kong/kong/blob/master/kong/plugins/aws-lambda/v4.lua) code and some parts for [getting the temporary credentials from AWS STS](https://github.com/Kong/kong/blob/master/kong/plugins/aws-lambda/iam-sts-credentials.lua). There are some considerable differences that will be outlined below:
 
 1. Unlike Kong-Lambda This plugin does not perform the Lambda invocation. But only signs the request coming from the consumer which Kong then forwards to the upstream that it is configured in the service that the plugin is bound to.
 2. The plugin works only with temporary credentials that are fetched from `sts.amazonaws.com` using [AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_RequestParameters), this requires some configuration in AWS which can be found above.
 3. This plugin has a low priority and is compatible with the rest of Kong plugins because as mentioned above, it only performs SIGV4 on the request and then appends the necessary headers to be authorized in AWS.
 
+## Open Source Attribution
 
-### Open Source Attribution
 * [Kong](https://github.com/Kong/kong) : [Apache 2.0 License](https://github.com/Kong/kong/blob/master/LICENSE)
 * [lua-resty-string](https://github.com/openresty/lua-resty-string) : [BSD License](https://github.com/openresty/lua-resty-string#copyright-and-license)
 * [Penlight](https://github.com/lunarmodules/Penlight) : [MIT License](https://github.com/lunarmodules/Penlight/blob/master/LICENSE.md)
 * [lua-resty-openssl](https://github.com/fffonion/lua-resty-openssl) : [BSD 2-Clause "Simplified" License](https://github.com/fffonion/lua-resty-openssl/blob/master/LICENSE)
-* [lua-resty-http](https://github.com/ledgetech/lua-resty-http) : [BSD 2-Clause "Simplified" License ](https://github.com/ledgetech/lua-resty-http/blob/master/LICENSE)
+* [lua-resty-http](https://github.com/ledgetech/lua-resty-http) : [BSD 2-Clause "Simplified" License](https://github.com/ledgetech/lua-resty-http/blob/master/LICENSE)
 * [lua-cjson](https://github.com/mpx/lua-cjson) : [MIT License](https://github.com/mpx/lua-cjson/blob/master/LICENSE)
 
-### License 
+## License
+
 [Modified Apache 2.0 (Section 6)](https://github.com/LEGO/kong-aws-request-signing/blob/main/LICENSE)

--- a/kong/plugins/aws-request-signing/schema.lua
+++ b/kong/plugins/aws-request-signing/schema.lua
@@ -4,12 +4,8 @@ return {
   name = "aws-request-signing",
   fields = {
     {
-      -- this plugin will only be applied to Services
+      -- this plugin will not be applied to consumers
       consumer = typedefs.no_consumer,
-    },
-    {
-      -- this plugin will only be applied to Services
-      route = typedefs.no_route
     },
     {
       -- this plugin will only run within Nginx HTTP module
@@ -35,6 +31,19 @@ return {
         { aws_service = {
           type = "string",
           required = true,
+        } },
+        { override_target_host = {
+          type = "string"
+        } },
+        { override_target_port = {
+          type = "number"
+        } },
+        { override_target_protocol = {
+          type = "string",
+              one_of = {
+                "http",
+                "https",
+              },
         } }
         }
       },


### PR DESCRIPTION
This PR allows the deployment of multiple Lambda endpoints as part of a single Kong service, by introducing the ability to override service upstream. 

This change allows the plugin to be used on a per-route basis and thus have multiple lambda routes that together form a service.

# About the PR
<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

## Changelog
- Add: Added 3 configuration options, to make possible target override.
- Add: Used those configuration options in the access phase of the plugin as proxy target if enabled.
- Update: Updated developer readme.
- Note: Both changes above are fully backward compatible.

### Testing
- [x] Has been tested locally and against a deployed lambda.

