### PR TITLE
Feat/better STS errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,11 +19,9 @@ aws_assume_role_arn - ARN of the IAM role that the plugin will try to assume
 type = "string"
 required = true
 
-
 aws_assume_role_name - Name of the role above.
 type = "string"
 required = true
-
 
 aws_region - AWS region where your Lambda is deployed to
 type = "string"
@@ -42,8 +40,13 @@ type = "number"
 required = false
 
 override_target_protocol - To be used when deploying a Lambda on a Kong service that has a protocol different than `https`
-type = "string",
+type = "string"
 one_of = "http", "https"
+required = false
+
+return_aws_sts_error - Whether to return the AWS STS response status and body when credentials fetching failed.
+type = "boolean"
+default = false
 required = false
 ```
 

--- a/kong-aws-request-signing-1.0.0-3.rockspec
+++ b/kong-aws-request-signing-1.0.0-3.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "aws-request-signing"
 local package_name = "kong-" .. plugin_name
-local package_version = "1.0.0"
+local package_version = "1.0.1"
 local rockspec_revision = "3"
 
 local github_account_name = "LEGO"

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -67,7 +67,9 @@ local function get_iam_credentials(sts_conf, refresh)
 
   if err then
     kong.log.err(err)
-    return kong.response.exit(401, { message = json.decode(err:gsub("failed to get from node cache:", "")) })
+    err:gsub("failed to get from node cache:", "")
+    local errJson = err:gsub("failed to get from node cache:", "")
+    return kong.response.exit(401, { message = json.decode(errJson)})
   end
 
   if not iam_role_credentials
@@ -81,7 +83,8 @@ local function get_iam_credentials(sts_conf, refresh)
     )
     if err then
       kong.log.err(err)
-      return kong.response.exit(401, { message = json.decode(err:gsub("failed to get from node cache:", "")) })
+      local errJson = err:gsub("failed to get from node cache:", "")
+      return kong.response.exit(401, { message = json.decode(errJson)})
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")
   end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -65,7 +65,7 @@ local function get_iam_credentials(sts_conf, refresh)
 
   if err then
     kong.log.err(err)
-    return kong.response.exit(401, { message = "Unable to get the IAM credentials! Check token!" })
+    return kong.response.exit(401, { message = err })
   end
 
   if not iam_role_credentials
@@ -79,7 +79,7 @@ local function get_iam_credentials(sts_conf, refresh)
     )
     if err then
       kong.log.err(err)
-      return kong.response.exit(401, { message = "Unable to refresh expired IAM credentials! Check token!" })
+      return kong.response.exit(401, { message = err })
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")
   end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -170,6 +170,6 @@ function AWSLambdaSTS:access(conf)
 end
 
 AWSLambdaSTS.PRIORITY = 110
-AWSLambdaSTS.VERSION = "1.0.0"
+AWSLambdaSTS.VERSION = "1.0.1"
 
 return AWSLambdaSTS

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -67,13 +67,12 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
 
   if err then
     kong.log.err(err)
-    local message = 'Error fetching STS credentials!'
     if(not (return_sts_error == nil) and return_sts_error == true ) then
       local errJson = err:gsub("failed to get from node cache:", "")
       local resError = json.decode(errJson)
-      return kong.response.exit(resError.sts_status, { message = message, stsResponse = resError.sts_body })
+      return kong.response.exit(resError.sts_status, { message = resError.message, stsResponse = resError.sts_body })
     else
-      return kong.response.exit(401, {message = message})
+      return kong.response.exit(401, {message = 'Error fetching STS credentials!'})
     end
   end
 
@@ -88,13 +87,12 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
     )
     if err then
       kong.log.err(err)
-      local message = 'Error fetching STS credentials!'
       if(not (return_sts_error == nil) and return_sts_error == true ) then
         local errJson = err:gsub("failed to get from node cache:", "")
         local resError = json.decode(errJson)
-        return kong.response.exit(resError.sts_status, { message = message, stsResponse = resError.sts_body })
+        return kong.response.exit(resError.sts_status, { message = resError.message, stsResponse = resError.sts_body })
       else
-        return kong.response.exit(401, { message = message })
+        return kong.response.exit(401, {message = 'Error fetching STS credentials!'})
       end
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -67,12 +67,13 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
 
   if err then
     kong.log.err(err)
+    local message = 'Error fetching STS credentials!'
     if(not (return_sts_error == nil) and return_sts_error == true ) then
       local errJson = err:gsub("failed to get from node cache:", "")
       local resError = json.decode(errJson)
-      return kong.response.exit(resError.sts_status, resError.sts_body)
+      return kong.response.exit(resError.sts_status, { message = message, stsResponse = resError.sts_body })
     else
-      return kong.response.exit(401, { message = 'Error fetching STS credentials!'})
+      return kong.response.exit(401, {message = message})
     end
   end
 
@@ -87,12 +88,13 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
     )
     if err then
       kong.log.err(err)
+      local message = 'Error fetching STS credentials!'
       if(not (return_sts_error == nil) and return_sts_error == true ) then
         local errJson = err:gsub("failed to get from node cache:", "")
         local resError = json.decode(errJson)
-        return kong.response.exit(resError.sts_status, resError.sts_body)
+        return kong.response.exit(resError.sts_status, { message = message, stsResponse = resError.sts_body })
       else
-        return kong.response.exit(401, { message = 'Error fetching STS credentials!'})
+        return kong.response.exit(401, { message = message })
       end
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -95,7 +95,7 @@ function AWSLambdaSTS:access(conf)
 
   if service == nil then
     kong.log.err("Unable to retrieve bound service!")
-    return kong.response.exit(500, { message = "Internal server error 1!" })
+    return kong.response.set_header("x-err", "unable to retrieve bound service").exit(500, { message = "Internal server error!" })
   end
 
   if conf.override_target_protocol then

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -69,7 +69,8 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
     kong.log.err(err)
     if(not (return_sts_error == nil) and return_sts_error == true ) then
       local errJson = err:gsub("failed to get from node cache:", "")
-      return kong.response.exit(401, { message = json.decode(errJson)})
+      local resError = json.decode(errJson)
+      return kong.response.exit(resError.sts_status, resError.sts_body)
     else
       return kong.response.exit(401, { message = 'Error fetching STS credentials!'})
     end
@@ -88,7 +89,8 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
       kong.log.err(err)
       if(not (return_sts_error == nil) and return_sts_error == true ) then
         local errJson = err:gsub("failed to get from node cache:", "")
-        return kong.response.exit(401, { message = json.decode(errJson)})
+        local resError = json.decode(errJson)
+        return kong.response.exit(resError.sts_status, resError.sts_body)
       else
         return kong.response.exit(401, { message = 'Error fetching STS credentials!'})
       end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -69,7 +69,7 @@ local function get_iam_credentials(sts_conf, refresh)
     kong.log.err(err)
     err:gsub("failed to get from node cache:", "")
     local errJson = err:gsub("failed to get from node cache:", "")
-    return kong.response.exit(401, { message = json.decode(errJson)})
+    return kong.response.set_header("www", "token to sts exchange error").exit(401, { message = json.decode(errJson)})
   end
 
   if not iam_role_credentials
@@ -84,7 +84,7 @@ local function get_iam_credentials(sts_conf, refresh)
     if err then
       kong.log.err(err)
       local errJson = err:gsub("failed to get from node cache:", "")
-      return kong.response.exit(401, { message = json.decode(errJson)})
+      return kong.response.set_header("www", "token to sts exchange error").exit(401, { message = json.decode(errJson)})
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")
   end
@@ -100,7 +100,7 @@ function AWSLambdaSTS:access(conf)
 
   if service == nil then
     kong.log.err("Unable to retrieve bound service!")
-    return kong.response.set_header("x-err", "unable to retrieve bound service").exit(500, { message = "Internal server error!" })
+    return kong.response.set_header("x-err", "unable to retrieve bound service").exit(500, { message = "Internal error!" })
   end
 
   if conf.override_target_protocol then

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -4,6 +4,8 @@ local kong = kong
 local ngx = ngx
 local error = error
 local type = type
+local json  = require "cjson"
+
 
 local set_headers = kong.service.request.set_headers
 local get_raw_body = kong.request.get_raw_body
@@ -65,7 +67,7 @@ local function get_iam_credentials(sts_conf, refresh)
 
   if err then
     kong.log.err(err)
-    return kong.response.exit(401, { message = err })
+    return kong.response.exit(401, { message = json.decode(err:gsub("failed to get from node cache:", "")) })
   end
 
   if not iam_role_credentials
@@ -79,7 +81,7 @@ local function get_iam_credentials(sts_conf, refresh)
     )
     if err then
       kong.log.err(err)
-      return kong.response.exit(401, { message = err })
+      return kong.response.exit(401, { message = json.decode(err:gsub("failed to get from node cache:", "")) })
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")
   end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -67,7 +67,7 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
 
   if err then
     kong.log.err(err)
-    if(not (return_sts_error == nil) and return_sts_error == true ) then
+    if(return_sts_error ~= nil and return_sts_error == true ) then
       local errJson = err:gsub("failed to get from node cache:", "")
       local resError = json.decode(errJson)
       return kong.response.exit(resError.sts_status, { message = resError.message, stsResponse = resError.sts_body })
@@ -87,7 +87,7 @@ local function get_iam_credentials(sts_conf, refresh, return_sts_error)
     )
     if err then
       kong.log.err(err)
-      if(not (return_sts_error == nil) and return_sts_error == true ) then
+      if(return_sts_error ~= nil and return_sts_error == true ) then
         local errJson = err:gsub("failed to get from node cache:", "")
         local resError = json.decode(errJson)
         return kong.response.exit(resError.sts_status, { message = resError.message, stsResponse = resError.sts_body })
@@ -133,7 +133,8 @@ function AWSLambdaSTS:access(conf)
     RoleSessionName = conf.aws_assume_role_name,
   }
 
-  local iam_role_credentials = get_iam_credentials(sts_conf, request_headers["x-sts-refresh"], conf.return_aws_sts_error)
+  local iam_role_credentials = get_iam_credentials(sts_conf, request_headers["x-sts-refresh"],
+                                                    conf.return_aws_sts_error)
 
   local upstream_headers = {
     ["x-authorization"] = kong.request.get_headers().authorization,

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -93,6 +93,11 @@ end
 function AWSLambdaSTS:access(conf)
   local service = kong.router.get_service()
 
+  if service == nil then
+    kong.log.err("Unable to retrieve bound service!")
+    return kong.response.exit(500, { message = "Internal server error 1!" })
+  end
+
   if conf.override_target_protocol then
     service.protocol = conf.override_target_protocol;
     kong.service.request.set_scheme(service.protocol)
@@ -104,11 +109,6 @@ function AWSLambdaSTS:access(conf)
   if conf.override_target_host then
     service.host = conf.override_target_host;
     kong.service.set_target(service.host, service.port)
-  end
-
-  if service == nil then
-    kong.log.err("Unable to retrieve bound service!")
-    return kong.response.exit(500, { message = "Internal server error" })
   end
 
   local request_headers = kong.request.get_headers()

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -64,8 +64,8 @@ local function get_iam_credentials(sts_conf, refresh)
   )
 
   if err then
-    kong.log.err(err.message)
-    return kong.response.exit(401, err)
+    kong.log.err(err)
+    return kong.response.exit(401, { message = err })
   end
 
   if not iam_role_credentials
@@ -78,8 +78,8 @@ local function get_iam_credentials(sts_conf, refresh)
       sts_conf
     )
     if err then
-      kong.log.err(err.message)
-      return kong.response.exit(401, err)
+      kong.log.err(err)
+      return kong.response.exit(401, { message = err })
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")
   end

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -64,8 +64,8 @@ local function get_iam_credentials(sts_conf, refresh)
   )
 
   if err then
-    kong.log.err(err)
-    return kong.response.exit(401, { message = err })
+    kong.log.err(err.message)
+    return kong.response.exit(401, err)
   end
 
   if not iam_role_credentials
@@ -78,8 +78,8 @@ local function get_iam_credentials(sts_conf, refresh)
       sts_conf
     )
     if err then
-      kong.log.err(err)
-      return kong.response.exit(401, { message = err })
+      kong.log.err(err.message)
+      return kong.response.exit(401, err)
     end
     kong.log.debug("expiring key , invalidated iam_cache and fetched fresh credentials!")
   end

--- a/kong/plugins/aws-request-signing/schema.lua
+++ b/kong/plugins/aws-request-signing/schema.lua
@@ -44,7 +44,12 @@ return {
                 "http",
                 "https",
               },
-        } }
+        } },
+        { return_aws_sts_error = {
+          type = "boolean",
+          required = false,
+          default = true,
+        } },
         }
       },
     }

--- a/kong/plugins/aws-request-signing/schema.lua
+++ b/kong/plugins/aws-request-signing/schema.lua
@@ -48,7 +48,7 @@ return {
         { return_aws_sts_error = {
           type = "boolean",
           required = false,
-          default = true,
+          default = false,
         } },
         }
       },

--- a/kong/plugins/aws-request-signing/schema.lua
+++ b/kong/plugins/aws-request-signing/schema.lua
@@ -47,7 +47,7 @@ return {
         } },
         { return_aws_sts_error = {
           type = "boolean",
-          required = false,
+          required = true,
           default = false,
         } },
         }

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -58,8 +58,8 @@ local function fetch_assume_role_credentials(assume_role_arn,
   if res.status ~= 200 then
     local err_s = json.encode({
       message  = 'Unable to assume role [' .. assume_role_arn .. ']',
-      sts_response_status = res.status,
-      sts_response_body = json.decode(res.body)
+      sts_status = res.status,
+      sts_body = json.decode(res.body)
     })
     return nil, err_s
   end

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -59,7 +59,7 @@ local function fetch_assume_role_credentials(assume_role_arn,
     local err_s = json.encode({
       message  = 'Unable to assume role [' .. assume_role_arn .. ']',
       sts_response_status = res.status,
-      str_response_body = json.decode(res.body)
+      sts_response_body = json.decode(res.body)
     })
     return nil, err_s
   end

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -48,19 +48,15 @@ local function fetch_assume_role_credentials(assume_role_arn,
   })
 
   if err then
-    local err_s = {
-      message  = 'Unable to assume role [' .. assume_role_arn .. ']',
-      error = tostring(err)
-    }
+    local err_s = 'Unable to assume role [' ..  assume_role_arn .. ']' ..
+                  ' due to: ' .. tostring(err)
     return nil, err_s
   end
 
   if res.status ~= 200 then
-    local err_s = {
-      message  = 'Unable to assume role [' .. assume_role_arn .. ']',
-      sts_response_status = res.status,
-      str_response_body = res.body
-    }
+    local err_s = 'Unable to assume role [' .. assume_role_arn .. '] due to:' ..
+                  'status [' .. res.status .. '] - ' ..
+                  'reason [' .. res.body .. ']'
     return nil, err_s
   end
 

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -59,7 +59,7 @@ local function fetch_assume_role_credentials(assume_role_arn,
     local err_s = {
       message  = 'Unable to assume role [' .. assume_role_arn .. ']',
       sts_response_status = res.status,
-      str_response_body = res.body
+      str_response_body = json.decode(res.body)
     }
     return nil, err_s
   end

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -48,19 +48,19 @@ local function fetch_assume_role_credentials(assume_role_arn,
   })
 
   if err then
-    local err_s = {
+    local err_s = json.encode({
       message  = 'Unable to assume role [' .. assume_role_arn .. ']',
       error = tostring(err)
-    }
+    })
     return nil, err_s
   end
 
   if res.status ~= 200 then
-    local err_s = {
+    local err_s = json.encode({
       message  = 'Unable to assume role [' .. assume_role_arn .. ']',
       sts_response_status = res.status,
       str_response_body = json.decode(res.body)
-    }
+    })
     return nil, err_s
   end
 

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -54,9 +54,11 @@ local function fetch_assume_role_credentials(assume_role_arn,
   end
 
   if res.status ~= 200 then
-    local err_s = 'Unable to assume role [' .. assume_role_arn .. '] due to:' ..
-                  'status [' .. res.status .. '] - ' ..
-                  'reason [' .. res.body .. ']'
+    local err_s = {
+      message  = 'Unable to assume role [' .. assume_role_arn .. ']',
+      sts_response_status = res.status,
+      str_response_body = res.body
+    }
     return nil, err_s
   end
 

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -48,8 +48,10 @@ local function fetch_assume_role_credentials(assume_role_arn,
   })
 
   if err then
-    local err_s = 'Unable to assume role [' ..  assume_role_arn .. ']' ..
-                  ' due to: ' .. tostring(err)
+    local err_s = {
+      message  = 'Unable to assume role [' .. assume_role_arn .. ']',
+      error = tostring(err)
+    }
     return nil, err_s
   end
 

--- a/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
+++ b/kong/plugins/aws-request-signing/webidentity-sts-credentials.lua
@@ -48,15 +48,19 @@ local function fetch_assume_role_credentials(assume_role_arn,
   })
 
   if err then
-    local err_s = 'Unable to assume role [' ..  assume_role_arn .. ']' ..
-                  ' due to: ' .. tostring(err)
+    local err_s = {
+      message  = 'Unable to assume role [' .. assume_role_arn .. ']',
+      error = tostring(err)
+    }
     return nil, err_s
   end
 
   if res.status ~= 200 then
-    local err_s = 'Unable to assume role [' .. assume_role_arn .. '] due to:' ..
-                  'status [' .. res.status .. '] - ' ..
-                  'reason [' .. res.body .. ']'
+    local err_s = {
+      message  = 'Unable to assume role [' .. assume_role_arn .. ']',
+      sts_response_status = res.status,
+      str_response_body = res.body
+    }
     return nil, err_s
   end
 


### PR DESCRIPTION
# About the PR
With the current setup, it might be tricky to spot the issue for sts creadentials fetch failure. This change allows returning the response from sts to the user, in case it fails.

## Changelog
- add: added new configuration parameter -> false by default.
- add: return either generic "failed to fetch sts creds" or the response code + response body from AWS sts.

### Testing

- [x] Has been tested locally.

### Other

- [x] Documentation has been updated (if applicable)
- [x] No linting errors
