### PR TITLE
Fix/ host race condition

### DIFF
--- a/kong-aws-request-signing-1.0.3-3.rockspec
+++ b/kong-aws-request-signing-1.0.3-3.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "aws-request-signing"
 local package_name = "kong-" .. plugin_name
-local package_version = "1.0.2"
+local package_version = "1.0.3"
 local rockspec_revision = "3"
 
 local github_account_name = "LEGO"

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -139,7 +139,7 @@ function AWSLambdaSTS:access(conf)
 
   -- we only send those two headers for signing
   local upstream_headers = {
-    host = service.host,
+    host = conf.override_target_host or service.host,
     ["x-authorization"] = request_headers.authorization
   }
 
@@ -153,7 +153,7 @@ function AWSLambdaSTS:access(conf)
     headers = upstream_headers,
     body = get_raw_body(),
     path = ngx.var.upstream_uri,
-    host = service.host,
+    host = conf.override_target_host or service.host,
     port = service.port,
     query = kong.request.get_raw_query(),
     access_key = iam_role_credentials.access_key,

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -175,6 +175,6 @@ function AWSLambdaSTS:access(conf)
 end
 
 AWSLambdaSTS.PRIORITY = 110
-AWSLambdaSTS.VERSION = "1.0.2"
+AWSLambdaSTS.VERSION = "1.0.3"
 
 return AWSLambdaSTS

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -107,6 +107,7 @@ end
 
 function AWSLambdaSTS:access(conf)
   local service = kong.router.get_service()
+  local request_headers = kong.request.get_headers()
 
   if service == nil then
     kong.log.err("Unable to retrieve bound service!")
@@ -114,19 +115,15 @@ function AWSLambdaSTS:access(conf)
   end
 
   if conf.override_target_protocol then
-    service.protocol = conf.override_target_protocol;
-    kong.service.request.set_scheme(service.protocol)
+    kong.service.request.set_scheme(conf.override_target_protocol)
   end
-  if conf.override_target_port then
-    service.port = conf.override_target_port;
-    kong.service.set_target(service.host, service.port)
+  if conf.override_target_port and conf.override_target_host then
+    kong.service.set_target(conf.override_target_host, conf.override_target_port)
   end
-  if conf.override_target_host then
-    service.host = conf.override_target_host;
-    kong.service.set_target(service.host, service.port)
-  end
+  -- if conf.override_target_host then
+  --   kong.service.set_target(conf.override_target_host, service.port)
+  -- end
 
-  local request_headers = kong.request.get_headers()
 
   local sts_conf = {
     RoleArn = conf.aws_assume_role_arn,

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -120,9 +120,12 @@ function AWSLambdaSTS:access(conf)
   if conf.override_target_port and conf.override_target_host then
     kong.service.set_target(conf.override_target_host, conf.override_target_port)
   end
-  -- if conf.override_target_host then
-  --   kong.service.set_target(conf.override_target_host, service.port)
-  -- end
+  if conf.override_target_host then
+    kong.service.set_target(conf.override_target_host, service.port)
+  end
+  if conf.override_target_port then
+    kong.service.set_target(service.host, conf.override_target_port)
+  end
 
 
   local sts_conf = {


### PR DESCRIPTION
<!-- 
  IMPORTANT!! Ensure your commits are signed before opening the Pull Request !!IMPORTANT
  Why: https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html  
  How: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
-->

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

# About the PR
<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the current version, the service object is modified, which in the case of the plugin having the override host present, causes a race condition that might occasionally proxy the request to the wrong host.

## Changelog
<!--
Write what you've changed or attempting to make happen. This makes life a million times easier for reviewers.

As a style guide don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

- Fix: Fixed a race condition that caused requests to go to the wrong host.
- Remove: Removed property changes of the service reference.

## Definition of Done - are you done?

### Testing

- [x] Has been tested locally.

### Other

- [x] No linting errors
