### PR TITLE
feat: will now work with canary-release plugin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 This plugin will sign a request with AWS SIGV4 and temporary credentials from `sts.amazonaws.com` requested using an OAuth token.
 
-It enables the secure use of AWS [Lambda URLs](https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/) being registered as "Host" in a Kong service.
+The AWS SIGV4 signature enables secure proxying directly towards AWS services such as [Lambda URLs](https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/).
 
 At the same time it drives down cost and complexity by excluding the AWS API Gateway and allowing to use AWS Lambdas directly.
 
@@ -33,7 +33,7 @@ aws_service - AWS Service you are trying to access (lambda and s3 were tested)
 type = "string"
 required = true
 
-override_target_host - To be used when deploying multiple lambdas on a single Kong service (because lambdas have differennt URLs)
+override_target_host - To be used when deploying multiple lambdas on a single Kong service (because lambdas have different URLs)
 type = "string"
 required = false
 

--- a/Readme.md
+++ b/Readme.md
@@ -6,11 +6,13 @@
 
 This plugin will sign a request with AWS SIGV4 and temporary credentials from `sts.amazonaws.com` requested using an OAuth token.
 
-It enables the secure use of AWS Lambdas as upstreams in Kong using [Lambda URLs](https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/).
+It enables the secure use of AWS [Lambda URLs](https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/) being registered as "Host" in a Kong service.
 
 At the same time it drives down cost and complexity by excluding the AWS API Gateway and allowing to use AWS Lambdas directly.
 
 The required AWS setup to make the plugin work with your Lambda HTTPS endpoint is described below.
+
+Note that this plugin cannot be used in combination with Kong [upstreams](https://docs.konghq.com/gateway/latest/get-started/load-balancing/).
 
 ## Plugin configuration parameters
 
@@ -111,8 +113,8 @@ plugins:
 
 ## Signing requests containing a body
 
-In case of requests contanining a body, the plugin is highly reliant on the nginx configuration, because it neets to access the body to sign it.
-The behaviour is controlled by the following Kong configuration parameters:
+In case of requests containing a body, the plugin is highly reliant on the nginx configuration, because it needs to access the body to sign it.
+The behavior is controlled by the following Kong configuration parameters:
 
 ```text
 nginx_http_client_max_body_size
@@ -135,7 +137,7 @@ The default value for max body size is `0`, which means unlimited, so consider s
 </details>
 
 2. Your OpenID Connect provider is added to [AWS IAM](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/identity_providers)
-3. You have a role with  `arn:aws:iam::aws:policy/AWSLambda_FullAccess` and/or `arn:aws:iam::aws:policy/AmazonS3FullAccess`  permision (or any other permision that grants access to your desired AWS service ) and the trust relationship below:
+3. You have a role with  `arn:aws:iam::aws:policy/AWSLambda_FullAccess` and/or `arn:aws:iam::aws:policy/AmazonS3FullAccess`  permission (or any other permission that grants access to your desired AWS service ) and the trust relationship below:
 
 <details>
 <summary>Show JSON</summary>

--- a/kong-aws-request-signing-1.0.6-3.rockspec
+++ b/kong-aws-request-signing-1.0.6-3.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "aws-request-signing"
 local package_name = "kong-" .. plugin_name
-local package_version = "1.0.5"
+local package_version = "1.0.6"
 local rockspec_revision = "3"
 
 local github_account_name = "LEGO"

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -189,6 +189,6 @@ function AWSLambdaSTS:access(conf)
 end
 
 AWSLambdaSTS.PRIORITY = 15
-AWSLambdaSTS.VERSION = "1.0.5"
+AWSLambdaSTS.VERSION = "1.0.6"
 
 return AWSLambdaSTS

--- a/kong/plugins/aws-request-signing/handler.lua
+++ b/kong/plugins/aws-request-signing/handler.lua
@@ -103,7 +103,7 @@ end
 function AWSLambdaSTS:access(conf)
   local service = kong.router.get_service()
   local request_headers = kong.request.get_headers()
-  local final_host = conf.override_target_host or service.host
+  local final_host = conf.override_target_host or ngx.ctx.balancer_data.host
 
   if service == nil then
     kong.log.err("Unable to retrieve bound service!")
@@ -188,7 +188,7 @@ function AWSLambdaSTS:access(conf)
   kong.service.request.set_raw_query(signed_request.query)
 end
 
-AWSLambdaSTS.PRIORITY = 110
+AWSLambdaSTS.PRIORITY = 15
 AWSLambdaSTS.VERSION = "1.0.5"
 
 return AWSLambdaSTS


### PR DESCRIPTION
# About the PR
This PR will allow the aws-request-signing plugin to work in conjunction with the [Canary Release plugin](https://docs.konghq.com/hub/kong-inc/canary/). It achieves this by lowering the priority of the aws-request-signing plugin so that the signing will happen after the Canary Release plugin has determined the which host is the destination of the request. Furthermore a small code change will pick up the original service destination from an internal data structure that honors changes applied by the Canary Release plugin

## Changelog
- Add: Added support for co-existence with Canary Release plugin!

## Definition of Done - are you done?

### Testing
- [x] Has been tested locally.

### Other
- [x] Documentation has been updated (if applicable)
- [x] No linting errors
